### PR TITLE
build(mirror): Replace mirror with repo namespace

### DIFF
--- a/.gitlab/repository.json
+++ b/.gitlab/repository.json
@@ -1,5 +1,0 @@
-{
-  "name": "user-guide",
-  "url": "https://gitlab.com/friending/spec/user-guide",
-  "status": "mirror"
-}


### PR DESCRIPTION
Remove the explicit gitlab mirror.

The repository definition schema (`.repository/index.json`) will be updated to include a `project` field which will scope the namespace. This will remove the need for the .gitlab mirror directory, as mirrored projects will be pinned to a controlled namespace.